### PR TITLE
Add MySQL 8.0 index fields

### DIFF
--- a/format/index_description.go
+++ b/format/index_description.go
@@ -23,7 +23,7 @@ type IndexDescription struct {
 	Null         sql.NullString `db:"Null"`
 	IndexType    sql.NullString `db:"Index_type"`
 	IndexComment sql.NullString `db:"Index_comment"`
-	Visible      sql.NullBool   `db:"Visible"`
+	Visible      sql.NullString `db:"Visible"`
 	Expression   sql.NullString `db:"Expression"`
 }
 

--- a/format/index_description.go
+++ b/format/index_description.go
@@ -23,6 +23,8 @@ type IndexDescription struct {
 	Null         sql.NullString `db:"Null"`
 	IndexType    sql.NullString `db:"Index_type"`
 	IndexComment sql.NullString `db:"Index_comment"`
+	Visible      sql.NullBool   `db:"Visible"`
+	Expression   sql.NullString `db:"Expression"`
 }
 
 // IndexDescriptions is a set of index descriptions


### PR DESCRIPTION
`Visible` and `Expression` were added in MySQL 8.0: https://dev.mysql.com/doc/refman/8.0/en/show-index.html

Tested on MySQL 5.6, 5.7, and 8.0.