### PR TITLE
Add flag to sort tables alphabetically

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/go:1.20.6
+FROM cimg/go:1.22.0
 USER root
 WORKDIR /go/src/github.com/ntindall/sql-gen-doc
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Usage of ./bin/sql-gen-doc:
       a data source name for the database, e.g. user:password@tcp(mysql:3306)/database_name
   -o string
       the outfile to write the documentation to, if no outfile is specified, the output is written to stdout
-  --alphabetical
+  --sort-tables
       outputs tables in alphabetical order
 
-$ ./bin/sql-gen-doc -dsn 'user:password@tcp(localhost:3306)/database_to_generate' -o outfile.md --alphabetical
+$ ./bin/sql-gen-doc -dsn 'user:password@tcp(localhost:3306)/database_to_generate' -o outfile.md --sort-tables
 ```
 
 Additionally, the markdown file can be annotated with comments in order to have

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ Usage of ./bin/sql-gen-doc:
       a data source name for the database, e.g. user:password@tcp(mysql:3306)/database_name
   -o string
       the outfile to write the documentation to, if no outfile is specified, the output is written to stdout
+  --alphabetical
+      outputs tables in alphabetical order
 
-$ ./bin/sql-gen-doc -dsn 'user:password@tcp(localhost:3306)/database_to_generate' -out outfile.md
+$ ./bin/sql-gen-doc -dsn 'user:password@tcp(localhost:3306)/database_to_generate' -o outfile.md
 ```
 
 Additionally, the markdown file can be annotated with comments in order to have

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Usage of ./bin/sql-gen-doc:
   --alphabetical
       outputs tables in alphabetical order
 
-$ ./bin/sql-gen-doc -dsn 'user:password@tcp(localhost:3306)/database_to_generate' -o outfile.md
+$ ./bin/sql-gen-doc -dsn 'user:password@tcp(localhost:3306)/database_to_generate' -o outfile.md --alphabetical
 ```
 
 Additionally, the markdown file can be annotated with comments in order to have

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2,11 +2,13 @@ package cmd
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"flag"
 	"fmt"
 	"log"
 	"os"
+	"slices"
 
 	"github.com/go-sql-driver/mysql"
 	// We must import the mysql driver as it is required by sqlx.
@@ -16,15 +18,17 @@ import (
 )
 
 var (
-	flagDSN     *string
-	flagOutfile *string
-	logger      *log.Logger
+	flagDSN      *string
+	flagOutfile  *string
+	alphabetical *bool
+	logger       *log.Logger
 )
 
 func init() {
 	// Parse flags
 	flagDSN = flag.String("dsn", "", "a data source name for the database, e.g. user:password@tcp(mysql:3306)/database_name")
 	flagOutfile = flag.String("o", "", "the outfile to write the documentation to, if no outfile is specified, the output is written to stdout")
+	alphabetical = flag.Bool("alphabetical", false, "outputs tables in alphabetical order")
 	flag.Parse()
 
 	// Setup logging
@@ -52,6 +56,12 @@ func Execute() {
 	tables, err := format.GetTables(ctx, db, cfg.DBName)
 	if err != nil {
 		logger.Fatalf("couldn't query database for tables. reason: %s", err)
+	}
+
+	if *alphabetical {
+		slices.SortFunc(tables, func(a, b format.GetTablesRow) int {
+			return cmp.Compare(a.Name, b.Name)
+		})
 	}
 
 	markdown := &bytes.Buffer{}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -18,17 +18,17 @@ import (
 )
 
 var (
-	flagDSN      *string
-	flagOutfile  *string
-	alphabetical *bool
-	logger       *log.Logger
+	flagDSN     *string
+	flagOutfile *string
+	sortTables  *bool
+	logger      *log.Logger
 )
 
 func init() {
 	// Parse flags
 	flagDSN = flag.String("dsn", "", "a data source name for the database, e.g. user:password@tcp(mysql:3306)/database_name")
 	flagOutfile = flag.String("o", "", "the outfile to write the documentation to, if no outfile is specified, the output is written to stdout")
-	alphabetical = flag.Bool("alphabetical", false, "outputs tables in alphabetical order")
+	sortTables = flag.Bool("sort-tables", false, "outputs tables in alphabetical order")
 	flag.Parse()
 
 	// Setup logging
@@ -58,7 +58,7 @@ func Execute() {
 		logger.Fatalf("couldn't query database for tables. reason: %s", err)
 	}
 
-	if *alphabetical {
+	if *sortTables {
 		slices.SortFunc(tables, func(a, b format.GetTablesRow) int {
 			return cmp.Compare(a.Name, b.Name)
 		})

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ntindall/sql-gen-doc
 
-go 1.20
+go 1.22
 
 require (
 	github.com/go-sql-driver/mysql v1.8.1


### PR DESCRIPTION
This PR adds the option to sort tables alphabetically in the output schema file. If the flag is not set, tables will be output in whatever order returned by the query.

I tested by running on a DB with and without the flag and observed the correct output when the flag was set.